### PR TITLE
Specify coffee-react as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimosa-cjsx",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A Coffeescript JSX/React compiler for Mimosa",
   "author": "Bob Pace",
   "mainteners": [{
@@ -22,8 +22,8 @@
     "module",
     "react"
   ],
-  "dependencies": {
-    "coffee-react": "^0.1.1"
+  "peerDependencies": {
+    "coffee-react": "*"
   },
   "license": "MIT",
   "main": "./src",


### PR DESCRIPTION
Allows the "host" package to specify the exact version.
Updated package version to 1.1.0

@mtscout6 Is this what you suggested? It seems to work great for me
